### PR TITLE
fix: allow queryWithCursor on default index

### DIFF
--- a/src/query/queryWithCursor.spec.ts
+++ b/src/query/queryWithCursor.spec.ts
@@ -302,7 +302,6 @@ describe('Pagination', () => {
     const mockValueOfQuery = testClient.query.mock.calls[0][0];
     expect(mockValueOfQuery.KeyConditionExpression).toBe('#PK = :pk');
     expect(mockValueOfQuery.TableName).toBe(testTableConf.name);
-    expect(mockValueOfQuery.IndexName).toBe('default');
     expect(result.items).toStrictEqual(
       ITEMS.filter(item => item.pk === 'pk#products').sort((a, b) =>
         a.sk.localeCompare(b.sk),
@@ -322,7 +321,6 @@ describe('Pagination', () => {
     expect(typeof result.cursor).toBe('string');
     expect(testClient.query).toHaveBeenNthCalledWith(1, {
       TableName: testTableConf.name,
-      IndexName: 'default',
       KeyConditionExpression: '#PK = :pk',
       ExpressionAttributeNames: {
         '#PK': 'pk',
@@ -348,7 +346,6 @@ describe('Pagination', () => {
     expect(typeof result.cursor).toBe('string');
     expect(testClient.query).toHaveBeenNthCalledWith(1, {
       TableName: testTableConf.name,
-      IndexName: 'default',
       KeyConditionExpression: '#PK = :pk',
       ExpressionAttributeNames: {
         '#PK': 'pk',
@@ -379,7 +376,6 @@ describe('Pagination', () => {
     expect(typeof result.cursor).toBe('string');
     expect(testClient.query).toHaveBeenNthCalledWith(1, {
       TableName: testTableConf.name,
-      IndexName: 'default',
       KeyConditionExpression: '#PK = :pk',
       ExpressionAttributeNames: {
         '#PK': 'pk',
@@ -412,7 +408,6 @@ describe('Pagination', () => {
 
       expect(testClient.query).toHaveBeenNthCalledWith(i, {
         TableName: testTableConf.name,
-        IndexName: 'default',
         KeyConditionExpression: '#PK = :pk',
         ExpressionAttributeNames: {
           '#PK': 'pk',
@@ -521,5 +516,19 @@ describe('Pagination', () => {
     const mockValueOfQuery = testClient.query.mock.calls[1][0];
     expect(mockValueOfQuery.Limit).toBe(2);
     expect(mockValueOfQuery.ExclusiveStartKey).toBeDefined();
+  });
+
+  test('IndexName should be empty when querying using default index', async () => {
+    mockQuery = jest.spyOn(testClient, 'query');
+
+    await query({
+      where: {
+        pk: 'something',
+      },
+      limit: 5,
+    });
+
+    const calledParams = mockQuery.mock.calls[0];
+    expect(calledParams).not.toHaveProperty('IndexName');
   });
 });

--- a/src/query/queryWithCursor.ts
+++ b/src/query/queryWithCursor.ts
@@ -16,9 +16,11 @@ export async function queryWithCursor<T extends AnyObject>(
   dbClient: DocumentClient,
   table: TableConfig,
   filter: Filter<T>,
-  indexName = 'default',
+  indexName?: string,
 ): Promise<{ items: Array<T>; cursor?: string; scannedCount: number }> {
-  const { partitionKeyName, sortKeyName } = table.indexes[indexName];
+  const { partitionKeyName, sortKeyName } = table.indexes[
+    indexName || 'default'
+  ];
 
   if (!sortKeyName) {
     throw new Error('Expected sortKey to query');


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- [x] Fix an issue where it prevents using default index for querying with `queryWithCursor`

Root cause:
The default index param of `queryWithCursor` is defaulted to "default". In runtime, it will get translated to a dynamo DB query with an "IndexName" value of "default". That will result in this error "The table does not have the specified index: default"

![Screenshot 2023-09-15 at 13 51 43](https://github.com/oolio-group/dynamo-helper/assets/104054750/e057485a-fff7-4f8e-b9d8-b92457757582)


## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate)
