### PR TITLE
feat: added transact delete items & added support for parallel call for transactPutItems

### DIFF
--- a/src/DynamoHelper.ts
+++ b/src/DynamoHelper.ts
@@ -26,6 +26,7 @@ import {
   Filter,
   TableConfig,
 } from './types';
+import { transactDeleteItems } from './mutation/transactDeleteItems';
 
 export class DynamoHelper {
   table: TableConfig;
@@ -110,8 +111,14 @@ export class DynamoHelper {
 
   async transactPutItems(
     items: Array<AnyObject>,
-  ): Promise<PromiseResult<TransactWriteItemsOutput, AWSError>> {
+  ): Promise<Array<PromiseResult<TransactWriteItemsOutput, AWSError>>> {
     return transactPutItems(this.dbClient, this.table, items);
+  }
+
+  async transactDeleteItems(
+    keys: Array<DocumentClient.Key>,
+  ): Promise<Array<PromiseResult<TransactWriteItemsOutput, AWSError>>> {
+    return transactDeleteItems(this.dbClient, this.table, keys);
   }
 
   async updateItem<T extends AnyObject>(

--- a/src/mutation/transactDeleteItems.spec.ts
+++ b/src/mutation/transactDeleteItems.spec.ts
@@ -1,0 +1,55 @@
+import { TransactWriteItemsInput } from 'aws-sdk/clients/dynamodb';
+import { testClient, testTableConf } from '../testUtils';
+import { transactDeleteItems as transactDeleteItemsMethod } from './transactDeleteItems';
+
+describe('transactDeleteItems', () => {
+  const transactDeleteItems = transactDeleteItemsMethod.bind(
+    null,
+    testClient,
+    testTableConf,
+  );
+  const spy = jest.spyOn(testClient, 'transactWrite');
+
+  beforeEach(() => {
+    spy.mockReturnValue({
+      promise: jest.fn().mockResolvedValue({}),
+    });
+  });
+
+  test('exports function', () => {
+    expect(typeof transactDeleteItems).toBe('function');
+  });
+
+  test('promise rejection', async () => {
+    spy.mockReturnValue({
+      promise: jest.fn().mockRejectedValue([]),
+    });
+
+    await expect(
+      transactDeleteItems([{ pk: 'xxxx', sk: 'yyyy' }]),
+    ).rejects.toStrictEqual([]);
+  });
+
+  test('uses transactWrite', async () => {
+    await transactDeleteItems([
+      { pk: '1', sk: 'a' },
+      { pk: '2', sk: 'b' },
+    ]);
+    expect(spy).toHaveBeenCalledWith({
+      TransactItems: [
+        {
+          Delete: {
+            Key: { pk: '1', sk: 'a' },
+            TableName: testTableConf.name,
+          },
+        },
+        {
+          Delete: {
+            Key: { pk: '2', sk: 'b' },
+            TableName: testTableConf.name,
+          },
+        },
+      ],
+    } as TransactWriteItemsInput);
+  });
+});

--- a/src/mutation/transactDeleteItems.ts
+++ b/src/mutation/transactDeleteItems.ts
@@ -5,29 +5,29 @@ import { AnyObject, TableConfig } from '../types';
 import chunk from 'lodash/chunk';
 
 /**
- * Put multiple items in the DB as a transaction
+ * Delete multiple items in the DB as a transaction
  * Operation fails if any one of the item operation fails
  * @param items List of items
  */
-export function transactPutItems(
+export function transactDeleteItems(
   dbClient: DocumentClient,
   table: TableConfig,
-  items: Array<AnyObject>,
+  keys: Array<DocumentClient.Key>,
 ): Promise<
   Array<PromiseResult<DocumentClient.TransactWriteItemsOutput, AWSError>>
 > {
   // TransactWriteItems accepts maximum of 100 items, 4 MB total and 400 KB per each item
   // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
-  const batches = chunk(items, 100) as Array<AnyObject[]>;
+  const batches = chunk(keys, 100) as Array<AnyObject[]>;
 
   return Promise.all(
     batches.map(x =>
       dbClient
         .transactWrite({
           TransactItems: x.map<TransactWriteItem>(x => ({
-            Put: {
+            Delete: {
               TableName: table.name,
-              Item: x,
+              Key: x,
             },
           })),
         })


### PR DESCRIPTION
## Description
This PR adds 2 changes:
1. This PR adds support to make batch call on transactPutItems upto 100 as per [doc](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html)
2. We've added transactDeleteItems too.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
